### PR TITLE
Switch to the published janus-idp orchestrator plugin

### DIFF
--- a/charts/janus-idp-workflows/Chart.yaml
+++ b/charts/janus-idp-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: janus-idp-workflows
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "0.0.1"
 
 dependencies:

--- a/charts/janus-idp-workflows/values.yaml
+++ b/charts/janus-idp-workflows/values.yaml
@@ -49,8 +49,8 @@ backstage:
       - dynamic-plugins.default.yaml
       plugins:
       - disabled: false
-        integrity: sha512-xwLJA197QiblD4ziBGP6W7Lf7VOStdyNLc+MmIarYu54ivaUh5nhucw1bLTub1jjvgIJ/2fwcmhP8lGXI79pSg==
-        package: '@caponetto-tests/backstage-plugin-orchestrator-backend-dynamic@0.0.10'
+        integrity: sha512-4BsB2jdgzBNYpE0IcFYmlEgfu6HJnD9uX8ZpzzYHTkMs8AU3aWWb3PZG0nu/y5s8m0kr4TBbS++gePwRdqDrgw==
+        package: '@janus-idp/backstage-plugin-orchestrator-backend-dynamic@0.0.1'
         pluginConfig:
           orchestrator:
             dataIndexService:
@@ -58,12 +58,12 @@ backstage:
             editor:
               path: https://sandbox.kie.org/swf-chrome-extension/0.32.0
       - disabled: false
-        integrity: sha512-7Wur8JlvVCPG9afbcTp3Cy/BLnFtep+NoL4Z6cCbeeM1MSinhT1QP+kppuu5St8LdXCShfm2WsPDaxq/mWxAtA==
-        package: '@caponetto-tests/backstage-plugin-orchestrator@0.0.10'
+        integrity: sha512-QYwZ5MTckS1gQQIQUBoOboiGefCtkcG+S8IFPiJ+6rPEtjzmUpVL5TmG1hXCUHWBMJP/+tKxlpNQib2SMInRnA==
+        package: '@janus-idp/backstage-plugin-orchestrator@1.0.0'
         pluginConfig:
           dynamicPlugins:
             frontend:
-              caponetto-tests.backstage-plugin-orchestrator:
+              janus-idp.backstage-plugin-orchestrator:
                 appIcons:
                 - importName: OrchestratorIcon
                   module: OrchestratorPlugin


### PR DESCRIPTION
Get the package integrity using:

curl -s https://registry.npmjs.org/@janus-idp/backstage-plugin-orchestrator| jq '.versions."1.0.0".dist.integrity'
curl -s https://registry.npmjs.org/@janus-idp/backstage-plugin-orchestrator-backend-dynamic | jq '.versions."0.0.1".dist.integrity'

Signed-off-by: Roy Golan <rgolan@redhat.com>
